### PR TITLE
Stop a load of errors on reconnects

### DIFF
--- a/lib/ribbon.js
+++ b/lib/ribbon.js
@@ -32,7 +32,12 @@ var Ribbon = function(opts) {
   this.debugEvents = debug(this.debugPrefix+':events');
   this.debugAdaptor = debug(this.debugPrefix+':adaptor');
 
-  if(this.opts.autoRestart) this.on('dropped', this.restart.bind(this));
+  var self = this;
+  if(this.opts.autoRestart) {
+    this.on('dropped', function() {
+      self.restart();
+    });
+  }
 };
 
 util.inherits(Ribbon, EventEmitter);


### PR DESCRIPTION
The .bind was calling restart with the error object, which was being treated as a callback function and breaking a lot of things.
